### PR TITLE
fix: update .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -49,3 +49,12 @@ ccache binary
 
 gtest_output_test_golden_lin.txt binary
 mod_*_english.txt binary
+
+# These filetypes should be recognized as VDF, not ReScript
+*.res linguist-language=vdf
+**/*.res linguist-detectable=true
+
+# Do not export these files on download
+.gitattributes export-ignore
+.gitignore export-ignore
+.github export-ignore


### PR DESCRIPTION
- Corrected `.res` files to no longer be listed as "ReScript" files.
- GitHub specific files no longer included in "Download Zip".